### PR TITLE
Fixing compile for storage-proto-2

### DIFF
--- a/core/azure-core/pom.xml
+++ b/core/azure-core/pom.xml
@@ -14,7 +14,7 @@
   <groupId>com.azure</groupId>
   <artifactId>azure-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-preview.2</version>
+  <version>1.0.0-preview.3</version>
 
   <name>Microsoft Azure Java Core Library</name>
   <description>This package contains core types for Azure Java clients.</description>

--- a/keyvault/client/keys/pom.xml
+++ b/keyvault/client/keys/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-keyvault-keys</artifactId>
-  <version>4.0.0-preview.1</version>
+  <version>4.0.0-preview.2</version>
 
   <name>azure-keyvault-keys</name>
   <url>https://github.com/Azure/azure-sdk-for-java</url>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.0.0-preview.1</version>
+      <version>1.0.0-preview.3</version>
     </dependency>
 
     <dependency>

--- a/keyvault/client/secrets/pom.xml
+++ b/keyvault/client/secrets/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-keyvault-secrets</artifactId>
-  <version>4.0.0-preview.1</version>
+  <version>4.0.0-preview.2</version>
 
   <name>azure-keyvault-secrets</name>
   <url>https://github.com/Azure/azure-sdk-for-java</url>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.0.0-preview.1</version>
+      <version>1.0.0-preview.3</version>
     </dependency>
 
     <dependency>

--- a/pom.client.xml
+++ b/pom.client.xml
@@ -707,8 +707,9 @@
     <module>./appconfiguration/client</module>
     <module>./core</module>
     <module>./eventhubs/client</module>
+    <module>./identity/client</module>
     <module>./keyvault/client</module>
     <module>./sdk/tracing</module>
-    <module>./identity/client</module>
+    <module>./storage/client</module>
   </modules>
 </project>

--- a/storage/client/blob/pom.xml
+++ b/storage/client/blob/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.0.0-preview.2</version>
+      <version>1.0.0-preview.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -59,12 +59,6 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-test</artifactId>
-      <version>1.0.0-preview.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-identity</artifactId>
       <version>1.0.0-preview.1</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
- Changed Azure Core to preview.3 as it has breaking changes from preview.2
- Updated KeyVault to use preview.3 as it is using the new changes and updated it to preview.2
- Downgraded storage to use Azure Core preview.1 as the AutoREST code was built using that
- Removed duplicate dependency from storage
- Added storage to the client pom as a module